### PR TITLE
Bump nodejs runtime to 22

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 service: default
 env: standard
-runtime: nodejs14
+runtime: nodejs22
 automatic_scaling:
   target_cpu_utilization: 0.90
   min_instances: 0


### PR DESCRIPTION
## Summary
This PR bumps the nodejs runtime to `nodejs22` since google app engine deprecated the old version 